### PR TITLE
Configuration option for enabling highlighting of tags in item text

### DIFF
--- a/MMM-MicrosoftToDo.js
+++ b/MMM-MicrosoftToDo.js
@@ -36,27 +36,27 @@ Module.register('MMM-MicrosoftToDo', {
 
         // checkbox icon is added based on configuration
         if (this.config.showCheckbox) {
-            listItem.appendChild(document.createTextNode("▢ "))
+          listItem.appendChild(document.createTextNode('▢ '))
         }
 
         // display the (previously formatted) due date
-        if (taskDue != '') {
-            listItem.appendChild(document.createTextNode(taskDue))
+        if (taskDue !== '') {
+          listItem.appendChild(document.createTextNode(taskDue))
         }
-        
+
         // extract tags (#Tag) from subject an display them differently
         var subjectTokens = element.subject.match(/((#[^\s]+)|(?!\s)[^#]*|\s+)+?/g)
-        for (var i=0; i < subjectTokens.length; i++) {
-            if (subjectTokens[i].startsWith("#")) {
-                var tagNode =document.createElement('span')
-                tagNode.innerText = subjectTokens[i]
-                if (self.config.highlightTagColor != null) {
-                    tagNode.style.color = self.config.highlightTagColor
-                }
-                listItem.appendChild(tagNode)
-            } else {
-                listItem.appendChild(document.createTextNode(subjectTokens[i]))
+        for (var i = 0; i < subjectTokens.length; i++) {
+          if (subjectTokens[i].startsWith('#')) {
+            var tagNode = document.createElement('span')
+            tagNode.innerText = subjectTokens[i]
+            if (self.config.highlightTagColor != null) {
+              tagNode.style.color = self.config.highlightTagColor
             }
+            listItem.appendChild(tagNode)
+          } else {
+            listItem.appendChild(document.createTextNode(subjectTokens[i]))
+          }
         }
 
         // complete task when clicked on it

--- a/MMM-MicrosoftToDo.js
+++ b/MMM-MicrosoftToDo.js
@@ -9,9 +9,6 @@ Module.register('MMM-MicrosoftToDo', {
     // copy module object to be accessible in callbacks
     var self = this
 
-    // checkbox icon is added based on configuration
-    var checkbox = this.config.showCheckbox ? '▢ ' : ''
-
     // styled wrapper of the todo list
     var listWrapper = document.createElement('ul')
     listWrapper.style.maxWidth = this.config.maxWidth + 'px'
@@ -36,8 +33,32 @@ Module.register('MMM-MicrosoftToDo', {
         listItem.style.whiteSpace = 'nowrap'
         listItem.style.overflow = 'hidden'
         listItem.style.textOverflow = 'ellipsis'
-        var listItemText = document.createTextNode(checkbox + taskDue + element.subject)
-        listItem.appendChild(listItemText)
+
+        // checkbox icon is added based on configuration
+        if (this.config.showCheckbox) {
+            listItem.appendChild(document.createTextNode("▢ "))
+        }
+
+        // display the (previously formatted) due date
+        if (taskDue != '') {
+            listItem.appendChild(document.createTextNode(taskDue))
+        }
+        
+        // extract tags (#Tag) from subject an display them differently
+        var subjectTokens = element.subject.match(/((#[^\s]+)|(?!\s)[^#]*|\s+)+?/g)
+        for (var i=0; i < subjectTokens.length; i++) {
+            if (subjectTokens[i].startsWith("#")) {
+                var tagNode =document.createElement('span')
+                tagNode.innerText = subjectTokens[i]
+                if (self.config.highlightTagColor != null) {
+                    tagNode.style.color = self.config.highlightTagColor
+                }
+                listItem.appendChild(tagNode)
+            } else {
+                listItem.appendChild(document.createTextNode(subjectTokens[i]))
+            }
+        }
+
         // complete task when clicked on it
         if (self.config.completeOnClick) {
           listItem.onclick = function () {
@@ -131,6 +152,11 @@ Module.register('MMM-MicrosoftToDo', {
     // decide if the task due date should be shown in front of each todo list item, if it exists
     if (self.config.showDueDate === undefined) {
       self.config.showDueDate = false
+    }
+
+    // decide if tags should be highlighted
+    if (self.config.highlightTagColor === undefined) {
+      self.config.highlightTagColor = null
     }
 
     // format to display the due date

--- a/MMM-MicrosoftToDo.js
+++ b/MMM-MicrosoftToDo.js
@@ -130,7 +130,7 @@ Module.register("MMM-MicrosoftToDo", {
         var titleTokens = element.title.match(/((#[^\s]+)|(?!\s)[^#]*|\s+)+?/g);
         for (var i = 0; i < titleTokens.length; i++) {
           if (titleTokens[i].startsWith("#")) {
-            var tagNode = document.createElement("span")
+            var tagNode = document.createElement("span");
             tagNode.innerText = titleTokens[i];
             if (self.config.highlightTagColor != null) {
               tagNode.style.color = self.config.highlightTagColor;

--- a/README.MD
+++ b/README.MD
@@ -92,12 +92,13 @@ modules: [
       oauth2ClientId: '4ef19f40-4892-4905-b999-76041e991f53',
       listName: 'Shopping List', // optional parameter: if not specified displays tasks from default "Tasks" list, if specified will look for a task list with the specified name (exact spelling)
       // Optional parameter:  see Planned Tasks Configuration
-      plannedTasks: { 
+      plannedTasks: {
         enabled: false
       }
       showCheckbox: true, // optional parameter: default value is true and will show a checkbox before each todo list item
       showDueDate: false, // optional parameter: default value is false and will show the todo list items due date if it exists on the todo list item
       dateFormat: 'ddd MMM Do [ - ]', //optional parameter: uses moment date format and the default value is 'ddd MMM Do [ - ]'
+      highlightTagColor: "#E3FF30" // optional parameter: highlight tags (#Tags) in the entry text. value can be a HTML color value
       hideIfEmpty: false, // optional parameter: default value is false and will show the module also when the todo list is empty
       maxWidth: 450, // optional parameter: max width in pixel, default value is 450
       itemLimit: 200, // optional parameter: limit on the number of items to show from the list, default value is 200
@@ -116,7 +117,7 @@ Microsoft ToDo offers a Planned smart list which shows tasks with a due date acr
 When enabled, the `listName` parameter is ignored, and tasks are retrieved from all lists which match the following criteria:
 * Task Status is not equal to `completed`
 * Task DueDate is set
-* Task Due date is less than the current date + the configured duration. 
+* Task Due date is less than the current date + the configured duration.
 
 In other words, if you just enable the Planned Tasks configuration, the default values for `duration` and `includedLists` will take tasks from all lists which are not completed and have a due date less than 2 weeks from today.  That will include any tasks that are overdue.
 


### PR DESCRIPTION
Hi, I have expanded the module's functionality be enabling tags (the strings prefixed with "#") to be highlighted in a custom color.

The configuration option is "highlightTagColor", for example:
```
highlightTagColor: "#E3FF30" // optional parameter: hightlight tags (#Tags) in the entry text. value can be a HTML color value
```

Maybe you are interested in this modification.

Greetings,
  Benjamin