### PR TITLE
Fixed DueDate coloring in conjunction with tag coloring

### DIFF
--- a/MMM-MicrosoftToDo.js
+++ b/MMM-MicrosoftToDo.js
@@ -128,18 +128,19 @@ Module.register("MMM-MicrosoftToDo", {
 
         // extract tags (#Tag) from subject an display them differently
         var titleTokens = element.title.match(/((#[^\s]+)|(?!\s)[^#]*|\s+)+?/g);
-        for (var i = 0; i < titleTokens.length; i++) {
-          if (titleTokens[i].startsWith("#")) {
+
+        titleTokens.forEach((token) => {
+          if (token.startsWith("#")) {
             var tagNode = document.createElement("span");
-            tagNode.innerText = titleTokens[i];
+            tagNode.innerText = token;
             if (self.config.highlightTagColor != null) {
               tagNode.style.color = self.config.highlightTagColor;
             }
-            listItem.appendChild(tagNode);
+            listSpan.appendChild(tagNode);
           } else {
-            listItem.appendChild(document.createTextNode(titleTokens[i]));
+            listSpan.appendChild(document.createTextNode(token));
           }
-        }
+        });
 
         listItem.appendChild(listSpan);
 

--- a/README.MD
+++ b/README.MD
@@ -106,7 +106,8 @@ modules: [
       completeOnClick: true, // optional parameter: default value is false, when set to true complete task when clicking on it
       refreshSeconds: 60, // optional parameter: every how many seconds should the list be updated from the remote service, default value is 60
       fade: true, //optional parameter: default value is false. True will fade the list towards the bottom from the point set in the fadePoint parameter
-      fadePoint: 0.5 //optional parameter: decimal value between 0 and 1 sets the point where the fade effect will start
+      fadePoint: 0.5 //optional parameter: decimal value between 0 and 1 sets the point where the fade effect will start,
+      colorDueDate: false // optional parameter: default value is false.  True will display colors for overdue (red), upcoming (orange), and future (green) dates
     }
   },
 ]

--- a/node_helper.js
+++ b/node_helper.js
@@ -148,7 +148,7 @@ module.exports = NodeHelper.create({
         if (listIds.length > 0) {
           self.getTasks(accessToken, config, listIds);
         } else {
-          self.logError({
+          self.logErrorObject({
             error: `"${config.listName}" task folder not found`,
             errorDescription: `The task folder "${config.listName}" could not be found.`
           });
@@ -264,12 +264,9 @@ module.exports = NodeHelper.create({
     return json;
   },
   logError: function (error) {
-    const jsonError = JSON.stringify(error);
-
-    if (jsonError) {
-      Log.error(`[MMM-MicrosoftToDo]: ${jsonError}`);
-    } else {
-      Log.error(`[MMM-MicrosoftToDo]: ${error}`);
-    }
+    Log.error(`[MMM-MicrosoftToDo]: ${error}`);
+  },
+  logErrorObject: function (errorObject) {
+    Log.error(`[MMM-MicrosoftToDo]: ${JSON.stringify(errorObject)}`);
   }
 });


### PR DESCRIPTION
It looks like my PR included some work I had on adding coloring for due dates (red if overdue, orange due in the next day, green future).  This change collided with some of the changes made to color tags in a task (#tagname) 

I updated the tag builder to append to the appropriate object, and moved to a `.foreach` call to get rid of some errors in ESLint.  Additionally, I updated the readme to document the change I made to color due dates.