### PR TITLE
Refactor to Use Dynamic Import for node-fetch due to ESM Adoption

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -6,13 +6,19 @@
   webSecurity in Electron.
 */
 var NodeHelper = require("node_helper");
-const fetch = require("node-fetch");
 const Log = require("logger");
 const { add, formatISO9075, compareAsc, parseISO } = require("date-fns");
 const { RateLimit } = require("async-sema");
 
 module.exports = NodeHelper.create({
-  start: function () {
+  async initialize() {
+    const fetchModule = await import('node-fetch');
+    this.fetch = fetchModule.default;
+    // You can call any other initialization methods here if needed.
+  },
+  
+  async start() {
+    await this.initialize();
     Log.info(`${this.name} node_helper started ...`);
   },
 


### PR DESCRIPTION
## Summary of Changes

This pull request addresses compatibility issues arising from the `node-fetch` module transitioning to ECMAScript modules (ESM). The MagicMirror module codebase predominantly utilizes the CommonJS module system, and direct `require()` of ESM-based modules is no longer supported. As such, this PR introduces asynchronous dynamic imports for the `node-fetch` module to ensure compatibility and seamless functionality.

## Details

### The Problem

Recent versions of `node-fetch` have transitioned to using ESM. When our MagicMirror module attempts to `require('node-fetch')`, Node.js throws an error:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /path/to/node-fetch/src/index.js from /path/to/MMM-MicrosoftToDo/node_helper.js not supported.
```

This error effectively prevents the module from functioning as expected, rendering key functionalities inoperable.

### The Solution

To address this, the following changes were made:

1. Removed the direct `require` statement for `node-fetch`.
2. Introduced an `initialize` method within the `NodeHelper` module to handle the dynamic import of `node-fetch`.
3. Adjusted the `start` method to ensure `fetch` is loaded before other methods are executed.

These changes introduce asynchronous behavior to the module loading process, but are necessary for compatibility with modules that have adopted ESM.

Thank you for considering this pull request. Feedback and modifications are welcome!
